### PR TITLE
new: document SeeClickFix, CivicPlus, and app store publisher info

### DIFF
--- a/content/encryption.md
+++ b/content/encryption.md
@@ -1,0 +1,12 @@
+Q: Do you support encryption at rest?
+A: We do not support encryption-at-rest for customer data. Encryption-at-rest mechanisms are h
+
+FYI, it wasn’t worth getting into the details with James, but encryption at rest doesn’t help with a hacker threat as James suggested he was concerned about.  It helps with physical theft of the disk storage.  So encryption at rest, if we implemented it, would be protecting us against someone with physical access to our data center taking our disk drives.  It doesn’t help in any particular way with someone hacking our systems.  It could also help with data snapshots that reside on our laptops.
+
+can you expand on why it’s not effective against a hacker?
+
+Because for our software systems to work, the systems need to have the unencrypted data.  The CRM wouldn’t be too useful if “Pothole on Main St.” showed up as “4cfc1c442647c0caf734ea56dcf9a57e29f87af66092638ed7f2ac795eca7f75".
+
+Encryption at rest is effectively a secure storage mechanism, when the data is accessed (by our database engine, for example) it is already unencrypted because the storage system has decrypted it before handing it over to the database software.  Since a hacker is effectively subverting our software in some way and that software has to have unencrypted data to work, the hack would also have access to the unencrypted data.
+
+This all works because our software hands a key to the storage subsystem.  If someone steals the disk, they don’t get the key to go with it and the data on the disk is effectively useless.

--- a/content/mobile-privacy-policy.md
+++ b/content/mobile-privacy-policy.md
@@ -1,0 +1,25 @@
+# Mobile App Privacy Policy Information
+
+This page provides information about the applicable privacy policy
+for mobile apps provided by SeeClickFix (a division of CivicPlus)
+and published in the Google Play and Apple App stores by ourselves
+and our clients.
+
+The publisher of the mobile application that referred you to this
+page has contracted with CivicPlus to provide the app and the
+associated services.
+
+For specific information about the publisher and their endorsement
+of the SeeClickFix application and services, please return to the
+store listing.
+
+CivicPlus is a service provider and data custodian for the app publisher.
+
+* The CivicPlus Privacy Policy is available here
+[https://www.civicplus.com/privacy-policy](https://www.civicplus.com/privacy-policy).
+
+* The SeeClickFix Terms of Service are available here
+[https://legal.seeclickfix.com/terms-of-use](https://legal.seeclickfix.com/terms-of-use).
+
+* For more information about SeeClickFix and CivicPlus see
+[https://www.civicplus.com/seeclickfix/citizen-request-management](https://www.civicplus.com/seeclickfix/citizen-request-management).

--- a/content/mobile-privacy-policy.md
+++ b/content/mobile-privacy-policy.md
@@ -1,3 +1,7 @@
+---
+title: SeeClickFix Terms of Use
+---
+
 # Mobile App Privacy Policy Information
 
 This page provides information about the applicable privacy policy


### PR DESCRIPTION
This is a landing page for the privacy statement link on mobile
apps provided by SeeClickFix (a division of CivicPlus)
The page provides an explanation for the relationship between
the organization listed as the developer/publisher,
SeeClickFix, and CivicPlus.

The actual privacy policy is linked and resides on the CivicPlus
website.